### PR TITLE
Fix missing model selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import useSWR from "swr";
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -14,9 +14,19 @@ function App() {
   const { messages, send, currentModel, setModel } = useChatStore();
   const [text, setText] = useState("");
 
+  useEffect(() => {
+    if (models && models.length > 0 && !currentModel) {
+      setModel(models[0]);
+    }
+  }, [models, currentModel, setModel]);
+
   const handleSend = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!text) return;
+    if (!currentModel) {
+      alert("Please select a model first");
+      return;
+    }
     await send(text);
     setText("");
   };


### PR DESCRIPTION
## Summary
- default to the first available model
- warn if no model is selected when sending a chat message

## Testing
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ecbbdee9c8323bf37abf2be52c85b