### PR TITLE
Implement minimal RAG flow

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,9 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.11", features = ["json", "stream"] }
+qdrant-client = "1"
+reqwest = { version = "0.12", features = ["json", "stream"] }
+uuid = { version = "1", features = ["v4"] }
 async-stream = "0.3"
 futures-util = "0.3"
 

--- a/src-tauri/src/ollama_client.rs
+++ b/src-tauri/src/ollama_client.rs
@@ -6,14 +6,21 @@ use serde_json::Value;
 pub async fn chat(
     model: String,
     prompt: String,
+    system: Option<String>,
 ) -> Result<impl Stream<Item = String>, reqwest::Error> {
     let client = Client::new();
+    let mut messages = Vec::new();
+    if let Some(sys) = system {
+        messages.push(serde_json::json!({"role": "system", "content": sys}));
+    }
+    messages.push(serde_json::json!({"role": "user", "content": prompt}));
+
     let res = client
         .post("http://127.0.0.1:11434/api/chat")
         .json(&serde_json::json!({
             "model": model,
             "stream": true,
-            "messages": [{"role": "user", "content": prompt}],
+            "messages": messages,
         }))
         .send()
         .await?;

--- a/src-tauri/src/rag.rs
+++ b/src-tauri/src/rag.rs
@@ -1,0 +1,87 @@
+use reqwest::Client;
+use qdrant_client::{
+    payload::Payload,
+    qdrant::{CreateCollectionBuilder, Distance, PointStruct, SearchPointsBuilder, UpsertPointsBuilder, VectorParamsBuilder},
+    Qdrant,
+};
+use uuid::Uuid;
+
+const QDRANT_URL: &str = "http://127.0.0.1:6333";
+const COLLECTION: &str = "chat";
+const EMBED_MODEL: &str = "nomic-embed-text";
+const VECTOR_DIM: u64 = 768;
+
+pub async fn query(text: &str, top_k: usize) -> Result<Vec<String>, String> {
+    let http = Client::new();
+    let vector = embed(&http, text).await.map_err(|e| e.to_string())?;
+
+    let client = Qdrant::from_url(QDRANT_URL)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    if !client
+        .collection_exists(COLLECTION)
+        .await
+        .map_err(|e| e.to_string())?
+    {
+        client
+            .create_collection(
+                CreateCollectionBuilder::new(COLLECTION)
+                    .vectors_config(VectorParamsBuilder::new(VECTOR_DIM, Distance::Cosine)),
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+    }
+
+    let search_res = client
+        .search_points(
+            SearchPointsBuilder::new(COLLECTION, vector.clone(), top_k as u64)
+                .with_payload(true),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // store query for future searches, ignore errors
+    store(&client, vector, text).await;
+
+    let results = search_res
+        .result
+        .into_iter()
+        .filter_map(|p| {
+            p.payload.and_then(|payload| {
+                let value: serde_json::Value = payload.into();
+                value.get("text").and_then(|v| v.as_str()).map(|s| s.to_string())
+            })
+        })
+        .collect();
+
+    Ok(results)
+}
+
+async fn store(client: &Qdrant, vector: Vec<f32>, text: &str) {
+    let payload: Payload = serde_json::json!({ "text": text }).try_into().unwrap_or_default();
+    let point = PointStruct::new(Uuid::new_v4().to_string(), vector, payload);
+    let _ = client
+        .upsert_points(UpsertPointsBuilder::new(COLLECTION, vec![point]).wait(true))
+        .await;
+}
+
+async fn embed(client: &Client, text: &str) -> Result<Vec<f32>, reqwest::Error> {
+    let v: serde_json::Value = client
+        .post("http://127.0.0.1:11434/api/embeddings")
+        .json(&serde_json::json!({
+            "model": EMBED_MODEL,
+            "prompt": text,
+        }))
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    Ok(v["embedding"]
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .filter_map(|f| f.as_f64().map(|f| f as f32))
+        .collect())
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import "./App.css";
 import ModelPicker from "./components/ModelPicker";
 import ChatPane from "./components/ChatPane";

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useChatStore } from "../stores/chatStore";
 
 export default function ChatInput() {

--- a/src/components/ChatPane.tsx
+++ b/src/components/ChatPane.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { useChatStore } from "../stores/chatStore";
@@ -11,7 +10,7 @@ export default function ChatPane() {
         <div key={msg.id} className={msg.role === "user" ? "text-right" : "text-left"}>
           <ReactMarkdown
             components={{
-              code({ inline, className, children, ...props }) {
+              code({ inline, className, children, ...props }: any) {
                 const match = /language-(\w+)/.exec(className || "");
                 return !inline && match ? (
                   <SyntaxHighlighter language={match[1]} PreTag="div" {...props}>

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import useSWR from "swr";
 import { invoke } from "@tauri-apps/api/core";
 import { useChatStore } from "../stores/chatStore";

--- a/src/components/ToolsSidebar.tsx
+++ b/src/components/ToolsSidebar.tsx
@@ -1,11 +1,16 @@
-import React from "react";
+import { useChatStore } from "../stores/chatStore";
 
 const tools = ["Web Search", "File Read", "Code Exec"];
 
 export default function ToolsSidebar() {
+  const { ragEnabled, toggleRag } = useChatStore();
   return (
     <aside className="w-40 p-2 border-r hidden sm:block">
       <h2 className="font-bold mb-2">Tools</h2>
+      <div className="flex items-center gap-2 mb-2">
+        <input type="checkbox" checked={ragEnabled} onChange={toggleRag} />
+        <span>RAG</span>
+      </div>
       <ul className="space-y-1">
         {tools.map((t) => (
           <li key={t} className="flex items-center gap-2">

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -8,6 +8,8 @@ interface ChatState {
   messages: Message[];
   currentModel: string;
   setModel: (m: string) => void;
+  ragEnabled: boolean;
+  toggleRag: () => void;
   send: (text: string) => Promise<void>;
 }
 
@@ -15,6 +17,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
   messages: [],
   currentModel: "",
   setModel: (m) => set({ currentModel: m }),
+  ragEnabled: true,
+  toggleRag: () => set((s) => ({ ragEnabled: !s.ragEnabled })),
   send: async (text: string) => {
     const user: Message = { id: crypto.randomUUID(), role: "user", text };
     const assistant: Message = { id: crypto.randomUUID(), role: "assistant", text: "" };
@@ -37,6 +41,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       await invoke("generate_chat", {
         model: get().currentModel,
         prompt: text,
+        ragEnabled: get().ragEnabled,
       });
       await done;
     } catch (e) {


### PR DESCRIPTION
## Summary
- add Qdrant, uuid and reqwest 0.12 to the Tauri backend
- implement `rag.rs` for embedding, searching and storing prompts
- allow optional system prompts in `ollama_client::chat`
- wire up RAG into `generate_chat` command
- expose a RAG toggle in the UI and store
- clean up React imports and minor TS fixes

## Testing
- `pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: system library `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed977361c83238ff686309be0edc4