### PR TITLE
Add tool system with web search

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,17 @@ Simple Tauri + React client that streams responses from a local Ollama daemon.
 1. Drag a PDF into the drop zone.
 2. Wait for the "parsed" status.
 3. Send a message and future queries can reference the file.
+
+## Tool system
+
+Tools let the assistant perform external actions. Each tool implements the `Tool` trait on the Rust side and is registered in `tool::registry()`. The frontend lists available tools via the `list_tools` command and you can enable them per chat.
+
+### Adding a tool
+
+1. Create a struct that implements `Tool`.
+2. Insert it into the registry in `tool.rs`.
+3. Optional: expose new IPC commands if needed.
+
+### Web Search
+
+This build includes a `web_search` tool that queries DuckDuckGo's Instant Answer API (no key required) and returns up to five results. All requests comply with DuckDuckGo's terms of service.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,8 @@ reqwest = { version = "0.12", features = ["json", "stream"] }
 uuid = { version = "1", features = ["v4"] }
 async-stream = "0.3"
 futures-util = "0.3"
+async-trait = "0.1"
+once_cell = "1"
 anyhow = "1"
 mime_guess = "2"
 pdf-extract = "0.9"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,8 @@ mod embeddings;
 mod vector_db;
 mod chunk;
 mod file_ingest;
+mod tool;
+mod web_search;
 
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
@@ -22,11 +24,24 @@ async fn list_models() -> Result<Vec<String>, String> {
 }
 
 #[tauri::command]
+fn list_tools() -> Vec<tool::ToolMeta> {
+    let map = tool::registry().read().unwrap();
+    map.values()
+        .map(|t| tool::ToolMeta {
+            name: t.name(),
+            description: t.description(),
+            json_schema: t.json_schema(),
+        })
+        .collect()
+}
+
+#[tauri::command]
 async fn generate_chat(
     window: tauri::Window,
     model: String,
     prompt: String,
     rag_enabled: bool,
+    enabled_tools: Vec<String>,
 ) -> Result<(), String> {
     let mut system_prompt = None;
     if rag_enabled {
@@ -40,16 +55,107 @@ async fn generate_chat(
         }
     }
 
-    let stream = ollama_client::chat(model, prompt, system_prompt)
-        .await
-        .map_err(|e| format!("failed to connect to Ollama: {e}"))?;
-    tauri::async_runtime::spawn(async move {
-        futures_util::pin_mut!(stream);
-        while let Some(tok) = stream.next().await {
-            let _ = window.emit("chat-token", tok);
+    let reg = tool::registry();
+    let tool_specs: Vec<serde_json::Value> = {
+        let map = reg.read().unwrap();
+        enabled_tools
+            .iter()
+            .filter_map(|n| map.get(n.as_str()))
+            .map(|t| {
+                serde_json::json!({
+                    "type": "function",
+                    "function": {
+                        "name": t.name(),
+                        "description": t.description(),
+                        "parameters": t.json_schema(),
+                    }
+                })
+            })
+            .collect()
+    };
+
+    let client = reqwest::Client::new();
+    let mut messages = Vec::new();
+    if let Some(sys) = system_prompt {
+        messages.push(serde_json::json!({"role": "system", "content": sys}));
+    }
+    messages.push(serde_json::json!({"role": "user", "content": prompt}));
+
+    loop {
+        let res = client
+            .post("http://127.0.0.1:11434/api/chat")
+            .json(&serde_json::json!({
+                "model": model,
+                "stream": true,
+                "messages": messages,
+                "tools": tool_specs,
+            }))
+            .send()
+            .await
+            .map_err(|e| format!("failed to connect to Ollama: {e}"))?;
+
+        let mut stream_resp = res.bytes_stream();
+        let mut buf = Vec::new();
+        let mut call: Option<(String, serde_json::Value)> = None;
+
+        while let Some(chunk) = stream_resp.next().await {
+            if let Ok(bytes) = chunk {
+                buf.extend_from_slice(&bytes);
+                while let Some(pos) = buf.iter().position(|b| *b == b'\n') {
+                    let line: Vec<u8> = buf.drain(..=pos).collect();
+                    let trimmed = String::from_utf8_lossy(&line).trim().to_string();
+                    if trimmed.is_empty() { continue; }
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&trimmed) {
+                        if let Some(content) = v["message"]["content"].as_str() {
+                            let _ = window.emit("chat-token", content.to_string());
+                        }
+                        if let Some(tc) = v["message"]["tool_calls"].as_array().and_then(|a| a.first()) {
+                            let name = tc["function"]["name"].as_str().unwrap_or("").to_string();
+                            let args_v = &tc["function"]["arguments"];
+                            let args = if args_v.is_string() {
+                                serde_json::from_str(args_v.as_str().unwrap_or("{}"))
+                                    .unwrap_or_default()
+                            } else {
+                                args_v.clone()
+                            };
+                            call = Some((name, args));
+                        }
+                        if v["done"].as_bool() == Some(true) {
+                            break;
+                        }
+                    }
+                }
+            }
         }
-        let _ = window.emit("chat-end", ());
-    });
+
+        if let Some((name, args)) = call {
+            let result = {
+                let map = reg.read().unwrap();
+                if let Some(tool) = map.get(name.as_str()) {
+                    match tool.call(args.clone()).await {
+                        Ok(r) => r,
+                        Err(e) => format!("⚠️ {}", e),
+                    }
+                } else {
+                    format!("⚠️ unknown tool: {}", name)
+                }
+            };
+            let _ = window.emit(
+                "tool-message",
+                serde_json::json!({"name": name, "content": result}),
+            );
+            messages.push(serde_json::json!({
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": name, "arguments": args}}],
+            }));
+            messages.push(serde_json::json!({"role": "tool", "name": name, "content": result}));
+            continue;
+        } else {
+            break;
+        }
+    }
+
+    let _ = window.emit("chat-end", ());
     Ok(())
 }
 
@@ -87,7 +193,7 @@ async fn attach_file(window: tauri::Window, path: String, thread_id: String) -> 
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet, list_models, generate_chat, attach_file])
+        .invoke_handler(tauri::generate_handler![greet, list_models, list_tools, generate_chat, attach_file])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/tool.rs
+++ b/src-tauri/src/tool.rs
@@ -1,0 +1,33 @@
+use async_trait::async_trait;
+use serde::Serialize;
+use serde_json::Value;
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use crate::web_search::WebSearchTool;
+
+#[async_trait]
+pub trait Tool: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn description(&self) -> &'static str;
+    fn json_schema(&self) -> Value;
+    async fn call(&self, args: Value) -> anyhow::Result<String>;
+}
+
+#[derive(Serialize)]
+pub struct ToolMeta {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub json_schema: Value,
+}
+
+pub fn registry() -> &'static RwLock<HashMap<&'static str, Box<dyn Tool + Send + Sync>>> {
+    static REG: Lazy<RwLock<HashMap<&'static str, Box<dyn Tool + Send + Sync>>>> = Lazy::new(|| {
+        let mut map: HashMap<&'static str, Box<dyn Tool + Send + Sync>> = HashMap::new();
+        map.insert("web_search", Box::new(WebSearchTool) as Box<dyn Tool + Send + Sync>);
+        // TODO: additional tools (file_read, file_write, shell_exec)
+        RwLock::new(map)
+    });
+    &REG
+}

--- a/src-tauri/src/web_search.rs
+++ b/src-tauri/src/web_search.rs
@@ -1,0 +1,47 @@
+use serde_json::{json, Value};
+use crate::tool::Tool;
+
+pub struct WebSearchTool;
+
+#[async_trait::async_trait]
+impl Tool for WebSearchTool {
+    fn name(&self) -> &'static str { "web_search" }
+
+    fn description(&self) -> &'static str { "Search the web and return brief results" }
+
+    fn json_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string", "description": "Search phrase" }
+            },
+            "required": ["query"]
+        })
+    }
+
+    async fn call(&self, args: Value) -> anyhow::Result<String> {
+        let q = args.get("query").and_then(|v| v.as_str()).unwrap_or_default();
+        if q.len() > 200 {
+            anyhow::bail!("query too long");
+        }
+        let resp: Value = reqwest::Client::new()
+            .get("https://api.duckduckgo.com/")
+            .query(&[("q", q), ("format", "json")])
+            .timeout(std::time::Duration::from_secs(5))
+            .send()
+            .await?
+            .json()
+            .await?;
+        let mut out = String::new();
+        if let Some(arr) = resp.get("RelatedTopics").and_then(|v| v.as_array()) {
+            for (i, t) in arr.iter().take(5).enumerate() {
+                if let (Some(text), Some(url)) = (t.get("Text").and_then(|v| v.as_str()), t.get("FirstURL").and_then(|v| v.as_str())) {
+                    if i > 0 { out.push('\n'); }
+                    out.push_str(&format!("* [{}]({}) – {}", text, url, q));
+                }
+            }
+        }
+        if out.is_empty() { out = "No results found".into(); }
+        Ok(out)
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,17 @@ import ModelPicker from "./components/ModelPicker";
 import ChatPane from "./components/ChatPane";
 import ChatInput from "./components/ChatInput";
 import ToolsSidebar from "./components/ToolsSidebar";
+import ToolPicker from "./components/ToolPicker";
 
 function App() {
   return (
     <div className="flex h-screen">
       <ToolsSidebar />
       <div className="flex flex-col flex-1 p-4">
-        <ModelPicker />
+        <div className="flex items-center gap-4">
+          <ModelPicker />
+          <ToolPicker />
+        </div>
         <ChatPane />
         <ChatInput />
       </div>

--- a/src/components/ChatPane.tsx
+++ b/src/components/ChatPane.tsx
@@ -8,6 +8,10 @@ export default function ChatPane() {
     <div className="flex-1 overflow-y-auto my-2">
       {messages.map((msg) => (
         <div key={msg.id} className={msg.role === "user" ? "text-right" : "text-left"}>
+          {msg.role === "tool" && (
+            <div className="bg-blue-50 text-sm p-2 rounded mb-1">🔧 {msg.text}</div>
+          )}
+          {msg.role !== "tool" && (
           <ReactMarkdown
             components={{
               code({ inline, className, children, ...props }: any) {
@@ -26,6 +30,7 @@ export default function ChatPane() {
           >
             {msg.text}
           </ReactMarkdown>
+          )}
           {msg.attachments && msg.attachments.length > 0 && (
             <div className="flex gap-2 justify-end">
               {msg.attachments.map((a) => (

--- a/src/components/ToolPicker.tsx
+++ b/src/components/ToolPicker.tsx
@@ -1,0 +1,34 @@
+import useSWR from "swr";
+import { invoke } from "@tauri-apps/api/core";
+import { useChatStore } from "../stores/chatStore";
+
+export type ToolMeta = {
+  name: string;
+  description: string;
+  json_schema: any;
+};
+
+// TODO: per-thread tool-permission modal
+
+export default function ToolPicker() {
+  const { enabledTools, toggleTool } = useChatStore();
+  const { data, mutate } = useSWR<ToolMeta[]>("tools", () => invoke("list_tools"));
+
+  return (
+    <div className="flex items-center gap-2">
+      {data?.map((t) => (
+        <label key={t.name} className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={enabledTools.includes(t.name)}
+            onChange={() => {
+              toggleTool(t.name);
+              mutate();
+            }}
+          />
+          {t.name}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -4,7 +4,7 @@ import { listen } from "@tauri-apps/api/event";
 
 export type Attachment = { name: string; mime: string; status: "processing" | "ready" | "error" };
 
-export type Message = { id: string; role: "user" | "assistant"; text: string; attachments?: Attachment[] };
+export type Message = { id: string; role: "user" | "assistant" | "tool"; text: string; attachments?: Attachment[] };
 
 interface ChatState {
   messages: Message[];
@@ -12,6 +12,8 @@ interface ChatState {
   setModel: (m: string) => void;
   ragEnabled: boolean;
   toggleRag: () => void;
+  enabledTools: string[];
+  toggleTool: (name: string) => void;
   send: (text: string, attachments: Attachment[]) => Promise<void>;
 }
 
@@ -21,19 +23,41 @@ export const useChatStore = create<ChatState>((set, get) => ({
   setModel: (m) => set({ currentModel: m }),
   ragEnabled: true,
   toggleRag: () => set((s) => ({ ragEnabled: !s.ragEnabled })),
+  enabledTools: [],
+  toggleTool: (name) =>
+    set((s) => {
+      const has = s.enabledTools.includes(name);
+      return { enabledTools: has ? s.enabledTools.filter((t) => t !== name) : [...s.enabledTools, name] };
+    }),
   send: async (text: string, attachments: Attachment[]) => {
     const user: Message = { id: crypto.randomUUID(), role: "user", text, attachments };
     const assistant: Message = { id: crypto.randomUUID(), role: "assistant", text: "" };
     set((state) => ({ messages: [...state.messages, user, assistant] }));
     const assistantId = assistant.id;
 
-    const unlisten = await listen<string>("chat-token", (e) => {
+    const unlistenToken = await listen<string>("chat-token", (e) => {
       set((state) => ({
         messages: state.messages.map((m) =>
           m.id === assistantId ? { ...m, text: m.text + e.payload } : m
         ),
       }));
     });
+
+    const unlistenTool = await listen<{ name: string; content: string }>(
+      "tool-message",
+      (e) => {
+        set((s) => {
+          const idx = s.messages.findIndex((m) => m.id === assistantId);
+          const msgs = [...s.messages];
+          msgs.splice(idx, 0, {
+            id: crypto.randomUUID(),
+            role: "tool",
+            text: e.payload.content,
+          });
+          return { messages: msgs };
+        });
+      }
+    );
 
     const done = new Promise<void>((resolve) => {
       listen("chat-end", () => resolve());
@@ -44,12 +68,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
         model: get().currentModel,
         prompt: text,
         ragEnabled: get().ragEnabled,
+        enabledTools: get().enabledTools,
       });
       await done;
     } catch (e) {
       console.error(e);
     } finally {
-      unlisten();
+      unlistenToken();
+      unlistenTool();
     }
   },
 }));


### PR DESCRIPTION
## Summary
- implement generic `Tool` trait and registry
- create `WebSearchTool` using DuckDuckGo
- expose `list_tools` IPC command and extend `generate_chat` for tool calls
- add React ToolPicker and update chat store/pane
- document tool system in README

## Testing
- `cargo check` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef240cc78832390897fd82c0f49b4