### PR TITLE
Fix compile errors by updating imports

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -336,12 +336,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -494,6 +488,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -650,12 +664,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,7 +694,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
- "time",
+ "time 0.3.41",
  "version_check",
 ]
 
@@ -991,17 +999,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "docx-rs"
-version = "0.4.17"
+name = "docx"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e593b51d4fe95d69d70fd40da4b314b029736302c986c3c760826e842fd27dc3"
+checksum = "e626dd790e185281674a1af083f2f031bdfa4953c23b8a4397265413a34dc7a7"
 dependencies = [
- "base64 0.13.1",
- "image",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "xml-rs",
+ "derive_more",
+ "log",
+ "strong-xml",
  "zip",
 ]
 
@@ -1539,16 +1544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,22 +2051,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "gif",
- "jpeg-decoder",
- "num-traits",
- "png",
- "tiff",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2197,6 +2176,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "jetscii"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f25cca2463cb19dbb1061eb3bd38a8b5e4ce1cc5a5a9fc0e02de486d92b9b05"
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,12 +2202,6 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
@@ -2879,9 +2858,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-stream",
- "docx-rs",
+ "async-trait",
+ "docx",
  "futures-util",
  "mime_guess",
+ "once_cell",
  "pdf-extract",
  "qdrant-client",
  "reqwest",
@@ -3249,7 +3230,7 @@ dependencies = [
  "indexmap 2.10.0",
  "quick-xml",
  "serde",
- "time",
+ "time 0.3.41",
 ]
 
 [[package]]
@@ -4132,7 +4113,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with_macros",
- "time",
+ "time 0.3.41",
 ]
 
 [[package]]
@@ -4339,6 +4320,31 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
  "unicode-properties",
+]
+
+[[package]]
+name = "strong-xml"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98c54661f58cdd722d87bd1836581aa1f9db078eb83374b2297cf363397e0e7f"
+dependencies = [
+ "jetscii",
+ "lazy_static",
+ "log",
+ "memchr",
+ "strong-xml-derive",
+ "xmlparser",
+]
+
+[[package]]
+name = "strong-xml-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360ad7fc699b2753db380ab3d08ec6b952486e74c631be793a0b5542e55fa6f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4589,7 +4595,7 @@ dependencies = [
  "syn 2.0.104",
  "tauri-utils",
  "thiserror 2.0.12",
- "time",
+ "time 0.3.41",
  "url",
  "uuid",
  "walkdir",
@@ -4811,17 +4817,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiff"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
-dependencies = [
- "flate2",
- "jpeg-decoder",
- "weezl",
-]
-
-[[package]]
 name = "tiktoken-rs"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4834,6 +4829,17 @@ dependencies = [
  "lazy_static",
  "parking_lot",
  "rustc-hash 1.1.0",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -5453,6 +5459,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -6175,10 +6187,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "xml-rs"
-version = "0.8.27"
+name = "xmlparser"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"
@@ -6346,14 +6358,16 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
 dependencies = [
  "byteorder",
+ "bzip2",
  "crc32fast",
- "crossbeam-utils",
  "flate2",
+ "thiserror 1.0.69",
+ "time 0.1.45",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,7 +32,7 @@ once_cell = "1"
 anyhow = "1"
 mime_guess = "2"
 pdf-extract = "0.9"
-docx-rs = "0.4"
+docx = "1"
 tiktoken-rs = "0.5"
 tokio-stream = "0.1"
 

--- a/src-tauri/src/chunk.rs
+++ b/src-tauri/src/chunk.rs
@@ -1,4 +1,4 @@
-use tiktoken_rs::{get_bpe_from_model, num_tokens};
+use tiktoken_rs::get_bpe_from_model;
 
 pub fn chunk_text(text: &str, max_tokens: usize) -> anyhow::Result<Vec<String>> {
     let enc = get_bpe_from_model("gpt-3.5-turbo")?;
@@ -6,7 +6,11 @@ pub fn chunk_text(text: &str, max_tokens: usize) -> anyhow::Result<Vec<String>> 
     let mut current = String::new();
 
     for line in text.lines() {
-        if num_tokens(&enc, &(current.clone() + line)) > max_tokens {
+        if enc
+            .encode_with_special_tokens(&(current.clone() + line))
+            .len()
+            > max_tokens
+        {
             out.push(current.trim().to_owned());
             current.clear();
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -129,16 +129,17 @@ async fn generate_chat(
         }
 
         if let Some((name, args)) = call {
-            let result = {
+            let tool = {
                 let map = reg.read().unwrap();
-                if let Some(tool) = map.get(name.as_str()) {
-                    match tool.call(args.clone()).await {
-                        Ok(r) => r,
-                        Err(e) => format!("⚠️ {}", e),
-                    }
-                } else {
-                    format!("⚠️ unknown tool: {}", name)
+                map.get(name.as_str()).cloned()
+            };
+            let result = if let Some(tool) = tool {
+                match tool.call(args.clone()).await {
+                    Ok(r) => r,
+                    Err(e) => format!("⚠️ {}", e),
                 }
+            } else {
+                format!("⚠️ unknown tool: {}", name)
             };
             let _ = window.emit(
                 "tool-message",

--- a/src-tauri/src/tool.rs
+++ b/src-tauri/src/tool.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use serde_json::Value;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 use crate::web_search::WebSearchTool;
 
@@ -22,10 +22,10 @@ pub struct ToolMeta {
     pub json_schema: Value,
 }
 
-pub fn registry() -> &'static RwLock<HashMap<&'static str, Box<dyn Tool + Send + Sync>>> {
-    static REG: Lazy<RwLock<HashMap<&'static str, Box<dyn Tool + Send + Sync>>>> = Lazy::new(|| {
-        let mut map: HashMap<&'static str, Box<dyn Tool + Send + Sync>> = HashMap::new();
-        map.insert("web_search", Box::new(WebSearchTool) as Box<dyn Tool + Send + Sync>);
+pub fn registry() -> &'static RwLock<HashMap<&'static str, Arc<dyn Tool + Send + Sync>>> {
+    static REG: Lazy<RwLock<HashMap<&'static str, Arc<dyn Tool + Send + Sync>>>> = Lazy::new(|| {
+        let mut map: HashMap<&'static str, Arc<dyn Tool + Send + Sync>> = HashMap::new();
+        map.insert("web_search", Arc::new(WebSearchTool) as Arc<dyn Tool + Send + Sync>);
         // TODO: additional tools (file_read, file_write, shell_exec)
         RwLock::new(map)
     });


### PR DESCRIPTION
## Summary
- remove removed `num_tokens` API usage
- switch to the `docx` crate and update parsing
- store tool registry in `Arc` to avoid holding locks across await
- fix async call in `generate_chat`

## Testing
- `cargo check --lib --no-default-features` *(fails: glib-sys missing)*

------
https://chatgpt.com/codex/tasks/task_e_686efad1fb1c8323ba326863a4e2e094