### PR TITLE
Add file read/write tools and permission system

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,8 @@ pdf-extract = "0.9"
 docx = "1"
 tiktoken-rs = "0.5"
 tokio-stream = "0.1"
+tokio = { version = "1", features = ["fs"] }
+path-clean = "0.1"
 
 [patch.crates-io]
 jetscii = { path = "../patches/jetscii" }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,0 +1,1 @@
+pub const WORKSPACE_DIR: &str = "./workspace";

--- a/src-tauri/src/file_tools.rs
+++ b/src-tauri/src/file_tools.rs
@@ -1,0 +1,91 @@
+use anyhow::Context;
+use async_trait::async_trait;
+use path_clean::PathClean;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use tokio::{fs, io::AsyncWriteExt};
+
+fn safe_path(rel: &str) -> anyhow::Result<PathBuf> {
+    let p = Path::new(crate::config::WORKSPACE_DIR).join(rel).clean();
+    if !p.starts_with(crate::config::WORKSPACE_DIR) {
+        anyhow::bail!("Path traversal detected");
+    }
+    Ok(p)
+}
+
+/// FILE READ ───────────────────────────────────────────
+pub struct FileReadTool;
+#[async_trait]
+impl crate::tool::Tool for FileReadTool {
+    fn name(&self) -> &'static str {
+        "file_read"
+    }
+    fn description(&self) -> &'static str {
+        "Read a UTF-8 text file from the workspace"
+    }
+    fn json_schema(&self) -> Value {
+        json!({
+          "type":"object",
+          "properties":{ "path": { "type":"string", "description":"Relative path inside workspace" } },
+          "required":["path"]
+        })
+    }
+    async fn call(&self, args: Value) -> anyhow::Result<String> {
+        let rel = args["path"].as_str().context("missing path")?;
+        let abs = safe_path(rel)?;
+        let data = fs::read_to_string(&abs)
+            .await
+            .with_context(|| format!("reading {}", rel))?;
+        Ok(if data.len() > 10_000 {
+            format!("(truncated) {}", &data[..10_000])
+        } else {
+            data
+        })
+    }
+}
+
+/// FILE WRITE ──────────────────────────────────────────
+pub struct FileWriteTool;
+#[async_trait]
+impl crate::tool::Tool for FileWriteTool {
+    fn name(&self) -> &'static str {
+        "file_write"
+    }
+    fn description(&self) -> &'static str {
+        "Write text content to a file in the workspace"
+    }
+    fn json_schema(&self) -> Value {
+        json!({
+          "type":"object",
+          "properties":{
+            "path":  { "type":"string" },
+            "content":{ "type":"string" },
+            "mode":  { "type":"string", "enum":["overwrite","append"], "default":"overwrite" }
+          },
+          "required":["path","content"]
+        })
+    }
+    async fn call(&self, args: Value) -> anyhow::Result<String> {
+        let rel = args["path"].as_str().context("missing path")?;
+        let content = args["content"].as_str().context("missing content")?;
+        let mode = args["mode"].as_str().unwrap_or("overwrite");
+        let abs = safe_path(rel)?;
+
+        if let Some(parent) = abs.parent() {
+            fs::create_dir_all(parent).await.ok();
+        }
+
+        let mut f = match mode {
+            "append" => {
+                fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&abs)
+                    .await?
+            }
+            _ => fs::File::create(&abs).await?,
+        };
+        f.write_all(content.as_bytes()).await?;
+        Ok(format!("Wrote {} bytes to {}", content.len(), rel))
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,13 +1,15 @@
 use futures_util::StreamExt;
 use tauri::Emitter;
 
+mod chunk;
+mod config;
+mod embeddings;
+mod file_ingest;
+mod file_tools;
 mod ollama_client;
 mod rag;
-mod embeddings;
-mod vector_db;
-mod chunk;
-mod file_ingest;
 mod tool;
+mod vector_db;
 mod web_search;
 
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
@@ -42,12 +44,22 @@ async fn generate_chat(
     prompt: String,
     rag_enabled: bool,
     enabled_tools: Vec<String>,
+    allowed_tools: Vec<String>,
+    _thread_id: String,
 ) -> Result<(), String> {
-    let mut system_prompt = None;
+    let mut system_prompt = String::new();
+    {
+        let map = tool::registry().read().unwrap();
+        system_prompt.push_str("| tool | description |\n| --- | --- |\n");
+        for t in enabled_tools.iter().filter_map(|n| map.get(n.as_str())) {
+            system_prompt.push_str(&format!("| {} | {} |\n", t.name(), t.description()));
+        }
+    }
+    system_prompt.push_str("The workspace directory is a sandbox. Use file_write only for plain-text.\nNEVER overwrite binary files.\n");
     if rag_enabled {
         if let Ok(ctx) = rag::query(&prompt, 4).await {
             if !ctx.is_empty() {
-                system_prompt = Some(format!(
+                system_prompt.push_str(&format!(
                     "Use the following context to answer the user:\n{}",
                     ctx.join("\n---\n")
                 ));
@@ -56,6 +68,13 @@ async fn generate_chat(
     }
 
     let reg = tool::registry();
+
+    for t in &enabled_tools {
+        if !allowed_tools.contains(t) {
+            return Err(serde_json::json!({"code":"NeedPermission","tool": t}).to_string());
+        }
+    }
+
     let tool_specs: Vec<serde_json::Value> = {
         let map = reg.read().unwrap();
         enabled_tools
@@ -76,8 +95,8 @@ async fn generate_chat(
 
     let client = reqwest::Client::new();
     let mut messages = Vec::new();
-    if let Some(sys) = system_prompt {
-        messages.push(serde_json::json!({"role": "system", "content": sys}));
+    if !system_prompt.is_empty() {
+        messages.push(serde_json::json!({"role": "system", "content": system_prompt}));
     }
     messages.push(serde_json::json!({"role": "user", "content": prompt}));
 
@@ -104,12 +123,17 @@ async fn generate_chat(
                 while let Some(pos) = buf.iter().position(|b| *b == b'\n') {
                     let line: Vec<u8> = buf.drain(..=pos).collect();
                     let trimmed = String::from_utf8_lossy(&line).trim().to_string();
-                    if trimmed.is_empty() { continue; }
+                    if trimmed.is_empty() {
+                        continue;
+                    }
                     if let Ok(v) = serde_json::from_str::<serde_json::Value>(&trimmed) {
                         if let Some(content) = v["message"]["content"].as_str() {
                             let _ = window.emit("chat-token", content.to_string());
                         }
-                        if let Some(tc) = v["message"]["tool_calls"].as_array().and_then(|a| a.first()) {
+                        if let Some(tc) = v["message"]["tool_calls"]
+                            .as_array()
+                            .and_then(|a| a.first())
+                        {
                             let name = tc["function"]["name"].as_str().unwrap_or("").to_string();
                             let args_v = &tc["function"]["arguments"];
                             let args = if args_v.is_string() {
@@ -194,7 +218,13 @@ async fn attach_file(window: tauri::Window, path: String, thread_id: String) -> 
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet, list_models, list_tools, generate_chat, attach_file])
+        .invoke_handler(tauri::generate_handler![
+            greet,
+            list_models,
+            list_tools,
+            generate_chat,
+            attach_file
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/tool.rs
+++ b/src-tauri/src/tool.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
+use once_cell::sync::Lazy;
 use serde::Serialize;
 use serde_json::Value;
-use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
@@ -23,11 +23,23 @@ pub struct ToolMeta {
 }
 
 pub fn registry() -> &'static RwLock<HashMap<&'static str, Arc<dyn Tool + Send + Sync>>> {
-    static REG: Lazy<RwLock<HashMap<&'static str, Arc<dyn Tool + Send + Sync>>>> = Lazy::new(|| {
-        let mut map: HashMap<&'static str, Arc<dyn Tool + Send + Sync>> = HashMap::new();
-        map.insert("web_search", Arc::new(WebSearchTool) as Arc<dyn Tool + Send + Sync>);
-        // TODO: additional tools (file_read, file_write, shell_exec)
-        RwLock::new(map)
-    });
+    static REG: Lazy<RwLock<HashMap<&'static str, Arc<dyn Tool + Send + Sync>>>> =
+        Lazy::new(|| {
+            let mut map: HashMap<&'static str, Arc<dyn Tool + Send + Sync>> = HashMap::new();
+            map.insert(
+                "web_search",
+                Arc::new(WebSearchTool) as Arc<dyn Tool + Send + Sync>,
+            );
+            map.insert(
+                "file_read",
+                Arc::new(crate::file_tools::FileReadTool) as Arc<dyn Tool + Send + Sync>,
+            );
+            map.insert(
+                "file_write",
+                Arc::new(crate::file_tools::FileWriteTool) as Arc<dyn Tool + Send + Sync>,
+            );
+            // TODO: shell_exec tool (limited commands, timeout, permission)
+            RwLock::new(map)
+        });
     &REG
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,10 +4,12 @@ import ChatPane from "./components/ChatPane";
 import ChatInput from "./components/ChatInput";
 import ToolsSidebar from "./components/ToolsSidebar";
 import ToolPicker from "./components/ToolPicker";
+import ToolPermissionModal from "./components/ToolPermissionModal";
 
 function App() {
   return (
     <div className="flex h-screen">
+      <ToolPermissionModal />
       <ToolsSidebar />
       <div className="flex flex-col flex-1 p-4">
         <div className="flex items-center gap-4">

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useChatStore } from "../stores/chatStore";
+import { usePermissionStore } from "../stores/permissionStore";
 import AttachmentDropZone, { PendingAttachment } from "./AttachmentDropZone";
 
 export default function ChatInput() {
@@ -7,6 +8,11 @@ export default function ChatInput() {
   const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
   const threadIdRef = useRef(crypto.randomUUID());
   const { send, currentModel } = useChatStore();
+  const { allowedToolsByThread, setThreadId } = usePermissionStore();
+
+  useEffect(() => {
+    setThreadId(threadIdRef.current);
+  }, [setThreadId]);
 
   const handle = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -15,10 +21,16 @@ export default function ChatInput() {
       alert("Pick a model first");
       return;
     }
-    await send(text, attachments);
+    await send(
+      text,
+      attachments,
+      threadIdRef.current,
+      allowedToolsByThread[threadIdRef.current] || []
+    );
     setText("");
     setAttachments([]);
     threadIdRef.current = crypto.randomUUID();
+    setThreadId(threadIdRef.current);
   };
 
   return (

--- a/src/components/ToolPermissionModal.tsx
+++ b/src/components/ToolPermissionModal.tsx
@@ -1,0 +1,33 @@
+import useSWR from "swr";
+import { invoke } from "@tauri-apps/api/core";
+import { usePermissionStore } from "../stores/permissionStore";
+import { ToolMeta } from "./ToolPicker";
+
+export default function ToolPermissionModal() {
+  const { pendingTool, grantPermission, denyPermission } = usePermissionStore();
+  const { data } = useSWR<ToolMeta[]>("tools", () => invoke("list_tools") as Promise<ToolMeta[]>);
+  const tool = data?.find((t) => t.name === pendingTool);
+  if (!pendingTool) return null;
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white p-4 rounded shadow w-80">
+        <h2 className="font-bold mb-2">Allow tool: {pendingTool}</h2>
+        <p className="mb-2 text-sm">{tool?.description}</p>
+        <p className="text-sm mb-4">
+          This tool can read or write files on your machine inside the workspace directory.
+        </p>
+        <div className="flex justify-end gap-2">
+          <button
+            className="border rounded px-3"
+            onClick={() => grantPermission(pendingTool)}
+          >
+            Allow
+          </button>
+          <button className="border rounded px-3" onClick={denyPermission}>
+            Deny
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ToolsSidebar.tsx
+++ b/src/components/ToolsSidebar.tsx
@@ -2,6 +2,8 @@ import { useChatStore } from "../stores/chatStore";
 
 const tools = ["Web Search", "File Read", "Code Exec"];
 
+// TODO: per-file RAG weighting UI
+
 export default function ToolsSidebar() {
   const { ragEnabled, toggleRag } = useChatStore();
   return (

--- a/src/stores/permissionStore.ts
+++ b/src/stores/permissionStore.ts
@@ -1,0 +1,38 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface PermState {
+  allowedToolsByThread: Record<string, string[]>;
+  currentThreadId: string;
+  pendingTool: string | null;
+  requestPermission: (tool: string) => void;
+  grantPermission: (tool: string) => void;
+  denyPermission: () => void;
+  setThreadId: (id: string) => void;
+}
+
+export const usePermissionStore = create<PermState>()(
+  persist(
+    (set) => ({
+      allowedToolsByThread: {},
+      currentThreadId: "",
+      pendingTool: null,
+      requestPermission: (tool) => set({ pendingTool: tool }),
+      grantPermission: (tool) =>
+        set((s) => {
+          const id = s.currentThreadId;
+          const existing = s.allowedToolsByThread[id] || [];
+          return {
+            pendingTool: null,
+            allowedToolsByThread: {
+              ...s.allowedToolsByThread,
+              [id]: existing.includes(tool) ? existing : [...existing, tool],
+            },
+          };
+        }),
+      denyPermission: () => set({ pendingTool: null }),
+      setThreadId: (id) => set({ currentThreadId: id }),
+    }),
+    { name: "permissions" }
+  )
+);


### PR DESCRIPTION
## Summary
- add workspace config and file read/write tools
- register new tools and gate them behind permissions
- track tool permissions per thread on frontend
- add modal UI for tool approval and integrate with chat
- update system prompt to include tool table and usage notes
- add TODO notes for future shell exec tool and RAG weighting

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f038206bc8323b5b465270b1d365b