### PR TITLE
fix json macro import in file tools

### DIFF
--- a/src-tauri/src/file_tools.rs
+++ b/src-tauri/src/file_tools.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use path_clean::PathClean;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
 use tokio::{fs, io::AsyncWriteExt};
 


### PR DESCRIPTION
## Summary
- import `json` macro in `file_tools`

## Testing
- `cargo check` *(fails: `gio-sys` missing `gio-2.0` pkg-config file)*

------
https://chatgpt.com/codex/tasks/task_e_686f05d5a540832396b6217d068d9966