### PR TITLE
Fix build errors

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ tokio-stream = "0.1"
 tokio = { version = "1", features = ["fs", "process", "time", "io-util"] }
 bytesize = "1"
 path-clean = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
 
 [patch.crates-io]
 jetscii = { path = "../patches/jetscii" }

--- a/src-tauri/src/shell_exec.rs
+++ b/src-tauri/src/shell_exec.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
-use serde_json::Value;
+use serde_json::{Value, json};
 use tokio::{process::Command, io::{AsyncReadExt, BufReader}, time::timeout};
 use anyhow::Context;
+use tauri::Emitter;
 
 const CMD_TIMEOUT_SECS: u64 = 5;
 const OUTPUT_LIMIT_BYTES: usize = 30 * 1024; // 30 KB
@@ -65,7 +66,7 @@ impl crate::tool::Tool for ShellExecTool {
             Ok::<(), anyhow::Error>(())
         };
         if timeout(std::time::Duration::from_secs(CMD_TIMEOUT_SECS), join).await.is_err() {
-            child.kill().ok();
+            let _ = child.kill().await;
             anyhow::bail!("Command timed out");
         }
         let text = String::from_utf8_lossy(&out);


### PR DESCRIPTION
## Summary
- import json! and Emitter in shell execution tool
- handle async kill on timeout
- add chrono with serde support

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: `glib-sys` build script missing system library)*

------
https://chatgpt.com/codex/tasks/task_e_686f0ec4449483238cc46c3708168869