### PR TITLE
Refactor chat components

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,10 +1,16 @@
 import { FormEvent, useRef, useState } from 'react'
 import { Textarea, Button } from '@/components/ui'
 
+/** Props for {@link ChatInput}. */
 export interface ChatInputProps {
+  /** Callback when message is submitted. */
   onSend: (text: string) => void
+
 }
 
+/**
+ * Input form for sending chat messages.
+ */
 export function ChatInput({ onSend }: ChatInputProps) {
   const [text, setText] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -3,13 +3,19 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { Avatar, AvatarFallback, AvatarImage, Badge } from '@/components/ui'
 import { cn } from '@/lib/utils'
 
+/** Roles supported by {@link ChatMessage}. */
 export type ChatRole = 'assistant' | 'user' | 'error' | 'system'
 
 export interface ChatMessageProps {
+  /** Sender role. */
   role: ChatRole
+  /** Message content. */
   text: string
 }
 
+/**
+ * Display a single chat message with avatar and Markdown rendering.
+ */
 export function ChatMessage({ role, text }: ChatMessageProps) {
   const isUser = role === 'user'
   return (

--- a/src/components/layout/ChatLayout.tsx
+++ b/src/components/layout/ChatLayout.tsx
@@ -2,21 +2,26 @@ import { ReactNode, useState } from 'react'
 import { Sheet, SheetContent, SheetTrigger, Button } from '@/components/ui'
 import { Sidebar } from './Sidebar'
 import { ScrollArea } from '@/components/ui'
-import { cn } from '@/lib/utils'
 import { ToolList } from '../tools/ToolList'
 import { Menu } from 'lucide-react'
 
+/** Props for {@link ChatLayout}. */
 export interface ChatLayoutProps {
+  /** Sidebar configuration. */
   sidebarProps: React.ComponentProps<typeof Sidebar>
+  /** Chat content nodes. */
   children: ReactNode
 }
 
+/**
+ * Main application shell combining sidebar, message stream and tool drawer.
+ */
 export function ChatLayout({ sidebarProps, children }: ChatLayoutProps) {
   const [toolsOpen, setToolsOpen] = useState(false)
   return (
     <div className="flex h-screen bg-bg-app text-white">
       <Sidebar {...sidebarProps} />
-      <div className="flex flex-col flex-1">
+      <div className="relative flex flex-col flex-1">
         <div className="sticky top-0 z-10 flex items-center justify-between bg-bg-app p-2 border-b border-white/10">
           <div className="flex items-center gap-2">
             {sidebarProps.chats.length > 0 && <span className="font-semibold">Chat</span>}
@@ -34,9 +39,13 @@ export function ChatLayout({ sidebarProps, children }: ChatLayoutProps) {
             </Sheet>
           </div>
         </div>
-        <ScrollArea className="flex-1 p-4 overflow-y-auto" id="chat-scroll">
+        <ScrollArea
+          className="flex-1 p-4 overflow-y-auto overscroll-contain scroll-smooth"
+          id="chat-scroll"
+        >
           {children}
         </ScrollArea>
+        <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-bg-app to-transparent" />
       </div>
     </div>
   )

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,12 +4,16 @@ import { ThemeToggle } from './ThemeToggle'
 import { cn } from '@/lib/utils'
 import { Menu } from 'lucide-react'
 
+/** Props for {@link Sidebar}. */
 export interface SidebarProps {
   chats: { id: string; title: string }[]
   onNewChat: () => void
   onSelectChat: (id: string) => void
 }
 
+/**
+ * Collapsible sidebar listing chats and settings.
+ */
 export function Sidebar({ chats, onNewChat, onSelectChat }: SidebarProps) {
   const [collapsed, setCollapsed] = useState(false)
 

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -2,6 +2,7 @@ import { Moon, Sun } from 'lucide-react'
 import { Button } from '@/components/ui'
 import { useTheme } from './theme-provider'
 
+/** Toggle between light and dark mode. */
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme()
   const isDark = theme === 'dark' || (theme === 'system' && typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches)

--- a/src/components/tools/ToolCard.tsx
+++ b/src/components/tools/ToolCard.tsx
@@ -1,4 +1,5 @@
 import { Card } from '@/components/ui'
+/** Props for {@link ToolCard}. */
 
 export interface ToolCardProps {
   name: string
@@ -6,6 +7,9 @@ export interface ToolCardProps {
   onClick?: () => void
 }
 
+/**
+ * Card representation of a tool.
+ */
 export function ToolCard({ name, description, onClick }: ToolCardProps) {
   return (
     <Card className="p-4 hover:bg-bg-panel/50 cursor-pointer" onClick={onClick}>

--- a/src/components/tools/ToolDetails.tsx
+++ b/src/components/tools/ToolDetails.tsx
@@ -1,9 +1,13 @@
+/** Props for {@link ToolDetails}. */
 export interface ToolDetailsProps {
   name: string
   description: string
   children?: React.ReactNode
 }
 
+/**
+ * Detailed view for a tool.
+ */
 export function ToolDetails({ name, description, children }: ToolDetailsProps) {
   return (
     <div className="p-4 space-y-2">

--- a/src/components/tools/ToolList.tsx
+++ b/src/components/tools/ToolList.tsx
@@ -1,10 +1,15 @@
 import { ToolCard } from './ToolCard'
 
+/** Description for each available tool. */
+
 const tools = [
   { name: 'RAG', description: 'Retrieval augmented generation' },
   { name: 'shell_exec', description: 'Execute shell commands' },
 ]
 
+/**
+ * List available tools in a scrollable stack.
+ */
 export function ToolList() {
   return (
     <div className="space-y-2">


### PR DESCRIPTION
## Summary
- expand ChatLayout with overscroll and gradient fade
- document component props and restructure for clarity
- polish UI components with JSDoc and helpful comments

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686f30c2cb2083238a3eb1081e59b4f2