### PR TITLE
Fix theme for model picker and scrolling

### DIFF
--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -22,7 +22,7 @@ export default function ModelPicker() {
 
   return (
     <select
-      className="border rounded p-1"
+      className="border-input bg-background text-foreground border rounded p-1"
       value={currentModel}
       onChange={(e) => {
         setModel(e.target.value)

--- a/src/components/layout/ChatLayout.tsx
+++ b/src/components/layout/ChatLayout.tsx
@@ -22,7 +22,7 @@ export interface ChatLayoutProps {
 export function ChatLayout({ sidebarProps, children, input }: ChatLayoutProps) {
   const [toolsOpen, setToolsOpen] = useState(false)
   return (
-    <div className="flex h-screen bg-bg-app text-white">
+    <div className="flex h-screen bg-bg-app text-foreground">
       <Sidebar {...sidebarProps} />
       <div className="relative flex flex-col flex-1">
         <div className="sticky top-0 z-10 flex items-center justify-between bg-bg-app p-2 border-b border-white/10">
@@ -43,7 +43,7 @@ export function ChatLayout({ sidebarProps, children, input }: ChatLayoutProps) {
             </Sheet>
           </div>
         </div>
-        <div className="relative flex-1">
+        <div className="relative flex-1 min-h-0">
           <ScrollArea
             className="h-full p-4 overflow-y-auto overscroll-contain scroll-smooth"
             id="chat-scroll"


### PR DESCRIPTION
## Summary
- update ModelPicker select styling so it works in both light and dark themes
- remove global `text-white` color and allow scroll area container to shrink properly

## Testing
- `npx vitest run` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f4240162c8323b1337ecc9775d3d7