### PR TITLE
Improve dialog theming & add tool status indicator

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -15,9 +15,9 @@ export function SettingsDialog() {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="outline">Open Settings</Button>
+        <Button variant="outline" aria-label="Settings">Open Settings</Button>
       </DialogTrigger>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md" showCloseButton={false}>
         <DialogHeader>
           <DialogTitle>Settings</DialogTitle>
           <DialogDescription>

--- a/src/components/ToolPicker.tsx
+++ b/src/components/ToolPicker.tsx
@@ -1,4 +1,3 @@
-
 import useSWR from "swr"
 import { invoke } from "@tauri-apps/api/core"
 import { ScrollArea, Separator, Switch } from '@/components/ui'
@@ -12,40 +11,17 @@ export type ToolMeta = {
 };
 
 
-function ToolCheckbox({
-  tool,
-  label,
-  onToggle,
-  isChecked,
-}: {
-  tool: ToolMeta
-  label?: string
-  onToggle: (name: string) => void
-  isChecked: boolean
-}) {
-  return (
-    <label className="flex items-center gap-2">
-      <input
-        type="checkbox"
-        checked={isChecked}
-        onChange={() => onToggle(tool.name)}
-        className="form-checkbox h-4 w-4"
-      />
-      <span className="select-none">{label ?? tool.name}</span>
-    </label>
-  )
-}
-
 export default function ToolPicker() {
-  const { data: tools, error, isLoading, mutate } = useTools()
-  const { enabledTools, toggleTool } = useChatStore()
+  const { enabledTools, toggleTool } = useChatStore();
   const { requestPermission, allowedToolsByThread, currentThreadId } =
-    usePermissionStore()
+    usePermissionStore();
+  const { data, mutate } = useSWR<ToolMeta[]>(
+    "tools",
+    () => invoke("list_tools") as Promise<ToolMeta[]>
+  );
 
-  const handleToggle = useCallback(
-    (name: string) => {
-      const isEnabled = enabledTools.includes(name)
-      const isAllowed = allowedToolsByThread[currentThreadId]?.includes(name)
+  const basic = data?.filter((t) => t.name !== "shell_exec") || [];
+  const exec = data?.find((t) => t.name === "shell_exec");
 
   const renderTool = (t: ToolMeta, label?: string) => (
     <div key={t.name} className="flex items-center justify-between gap-2">
@@ -82,52 +58,5 @@ export default function ToolPicker() {
         )}
       </div>
     </ScrollArea>
-
-      if (isEnabled || isAllowed) {
-        toggleTool(name)
-        mutate() // refresh tool list or states if needed
-      } else {
-        requestPermission(name)
-      }
-    },
-    [enabledTools, allowedToolsByThread, currentThreadId, toggleTool, requestPermission, mutate]
-  )
-
-  if (isLoading) {
-    return <div className="py-4 text-center text-sm text-gray-500">Loading tools…</div>
-  }
-
-  if (error) {
-    return <div className="py-4 text-center text-sm text-red-600">Failed to load tools</div>
-  }
-
-  const basicTools = tools!.filter((t) => t.name !== 'shell_exec')
-  const execTool = tools!.find((t) => t.name === 'shell_exec')
-
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-wrap gap-3">
-        {basicTools.map((tool) => (
-          <ToolCheckbox
-            key={tool.name}
-            tool={tool}
-            isChecked={enabledTools.includes(tool.name)}
-            onToggle={handleToggle}
-          />
-        ))}
-      </div>
-
-      {execTool && (
-        <div className="pt-4 border-t">
-          <h4 className="text-sm font-bold mb-2">Advanced Tools</h4>
-          <ToolCheckbox
-            tool={execTool}
-            label="⚠ shell_exec (risky)"
-            isChecked={enabledTools.includes(execTool.name)}
-            onToggle={handleToggle}
-          />
-        </div>
-      )}
-    </div>
   )
 }

--- a/src/components/ToolStatusIndicator.tsx
+++ b/src/components/ToolStatusIndicator.tsx
@@ -1,0 +1,18 @@
+import { useChatStore } from '../stores/chatStore'
+import { Badge } from './ui'
+
+export default function ToolStatusIndicator() {
+  const { enabledTools } = useChatStore()
+
+  if (enabledTools.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-1 text-xs">
+      {enabledTools.map((tool) => (
+        <Badge key={tool} variant="secondary">
+          {tool}
+        </Badge>
+      ))}
+    </div>
+  )
+}

--- a/src/components/layout/ChatLayout.tsx
+++ b/src/components/layout/ChatLayout.tsx
@@ -3,6 +3,7 @@ import { Sidebar } from './Sidebar'
 import { ScrollArea } from '@/components/ui'
 import ModelPicker from '../ModelPicker'
 import { SettingsDialog } from '@/components/SettingsDialog'
+import ToolStatusIndicator from '../ToolStatusIndicator'
 
 /** Props for {@link ChatLayout}. */
 export interface ChatLayoutProps {
@@ -28,6 +29,7 @@ export function ChatLayout({ sidebarProps, children, input }: ChatLayoutProps) {
           </div>
           <div className="flex items-center gap-2">
             <ModelPicker />
+            <ToolStatusIndicator />
             <SettingsDialog />
           </div>
         </div>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -55,7 +55,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-dropdown bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-dropdown bg-black/50 dark:bg-black/60",
         className
       )}
       {...props}
@@ -71,10 +71,13 @@ function DialogContent({
 }) {
   return (
     <DialogPrimitive.Portal>
-      <DialogPrimitive.Overlay className="fixed inset-0 bg-black/50 z-40" />
+      <DialogPrimitive.Overlay className="fixed inset-0 bg-black/50 dark:bg-black/60 z-40" />
 
       <DialogPrimitive.Content
-        className={cn("fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white rounded-lg p-6 shadow-lg z-50", className)}
+        className={cn(
+          "fixed left-1/2 top-1/2 z-50 w-3/4 max-h-[75vh] -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lg bg-background text-foreground p-6 shadow-lg",
+          className
+        )}
         {...props}
       >
         {showCloseButton && (
@@ -122,7 +125,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn("text-lg leading-none font-semibold text-foreground", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- restore valid ToolPicker implementation
- style dialogs for dark/light mode and fit 75% of viewport
- keep settings dialog trigger accessible while keeping text
- add ToolStatusIndicator component showing enabled tools
- surface active tools in chat layout

## Testing
- `pnpm exec vitest run --no-cache`

------
https://chatgpt.com/codex/tasks/task_e_686f67e9cce483238fd527e119ce4f08