### PR TITLE
Add switch accent color

### DIFF
--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -20,7 +20,7 @@ const Switch = React.forwardRef<
       className={cn(
         "relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50",
         "data-[state=unchecked]:bg-gray-200 dark:data-[state=unchecked]:bg-gray-600",
-        "data-[state=checked]:bg-primary",
+        "data-[state=checked]:bg-switch",
         className
       )}
       {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -44,6 +44,7 @@
   --border: hsl(240 5% 90%);
   --input: hsl(240 5% 90%);
   --ring: hsl(243 75% 59%);
+  --switch-accent: hsl(0 0% 75%);
   --chart-1: hsl(340 82% 52%);
   --chart-2: hsl(210 90% 50%);
   --chart-3: hsl(48 100% 50%);
@@ -210,6 +211,7 @@ button {
   --border: hsl(215 20% 20%);
   --input: hsl(215 20% 25%);
   --ring: hsl(262 80% 75%);
+  --switch-accent: hsl(0 0% 60%);
   --chart-1: hsl(340 82% 52%);
   --chart-2: hsl(210 90% 60%);
   --chart-3: hsl(48 100% 50%);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,6 +14,7 @@ export default {
         'bg-primary': 'var(--c-bg-primary)',
         'bg-surface': 'var(--c-bg-surface)',
         accent: 'var(--c-accent)',
+        switch: 'var(--switch-accent)',
         brand: {
           50: 'var(--brand-50)',
           100: 'var(--brand-100)',


### PR DESCRIPTION
## Summary
- style Switch with new `switch` color token
- define `--switch-accent` custom property for light/dark themes

## Testing
- `pnpm test` *(fails: Unable to find an accessible element with the role "button" and name "Settings")*

------
https://chatgpt.com/codex/tasks/task_e_686f68ba72e08323bb35ceb6cf628c60