### PR TITLE
Fix ToolPicker toggle logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,13 @@ import IndexPage from './pages'
 import { ThemeProvider } from '@/components/layout'
 import { Toaster } from '@/components/common'
 import { CommandPalette } from '@/components/commands'
+import ToolPermissionModal from '@/components/ToolPermissionModal'
 
 export default function App() {
   return (
     <ThemeProvider>
       <IndexPage />
+      <ToolPermissionModal />
       <CommandPalette />
       <Toaster />
     </ThemeProvider>

--- a/src/components/ToolPicker.tsx
+++ b/src/components/ToolPicker.tsx
@@ -52,16 +52,16 @@ export default function ToolPicker() {
 
   const renderSwitch = (t: ToolMeta, label?: string) => {
     const isChecked = enabledTools.includes(t.name)
-    const isDisabled =
-      !isChecked && !allowedToolsByThread[currentThreadId]?.includes(t.name)
+    const hasPermission = allowedToolsByThread[currentThreadId]?.includes(t.name)
 
     return (
       <div key={t.name} className="flex items-center justify-between gap-2">
         <span>{label || t.name}</span>
         <Switch
           checked={isChecked}
-          disabled={isDisabled}
           onCheckedChange={handleToggle(t)}
+          disabled={false}
+          aria-disabled={!hasPermission && !isChecked}
         />
       </div>
     )


### PR DESCRIPTION
## Summary
- render the tool permission modal at the app level so permission requests can be granted
- adjust `ToolPicker` so switches can be clicked even before permission is granted

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686f8d4354588323a16871feee0f756c