### PR TITLE
Improve chat input styling

### DIFF
--- a/src/components/chat/ChatInput.test.tsx
+++ b/src/components/chat/ChatInput.test.tsx
@@ -6,7 +6,7 @@ describe('ChatInput', () => {
   it('calls onSend', () => {
     const fn = vi.fn()
     render(<ChatInput onSend={fn} />)
-    const textarea = screen.getByPlaceholderText('Say something...') as HTMLTextAreaElement
+    const textarea = screen.getByPlaceholderText('Send a message...') as HTMLTextAreaElement
     fireEvent.change(textarea, { target: { value: 'hi' } })
     fireEvent.submit(textarea.closest('form') as HTMLFormElement)
     expect(fn).toHaveBeenCalledWith('hi')

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,7 +1,8 @@
-import { FormEvent, useRef, useState } from 'react'
+import { FormEvent, useEffect, useRef, useState } from 'react'
 import { Textarea, Button } from '@/components/ui'
 import { useHotkeys } from '@/lib/hooks/useHotkeys'
 import { useChatStore } from '@/stores/chatStore'
+import { SendHorizontal } from 'lucide-react'
 
 /** Props for {@link ChatInput}. */
 export interface ChatInputProps {
@@ -17,6 +18,10 @@ export function ChatInput({ onSend }: ChatInputProps) {
   const [text, setText] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const { messages } = useChatStore()
+
+  useEffect(() => {
+    textareaRef.current?.focus()
+  }, [])
 
   const sendMessage = () => {
     if (!text.trim()) return
@@ -52,19 +57,36 @@ export function ChatInput({ onSend }: ChatInputProps) {
     []
   )
 
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setText(e.target.value)
+    e.target.style.height = 'auto'
+    e.target.style.height = `${e.target.scrollHeight}px`
+  }
+
   return (
-    <form onSubmit={handleSubmit} className="flex items-end gap-2 p-2 border-t border-white/10">
-      <Textarea
-        ref={textareaRef}
-        className="flex-1 resize-none bg-transparent focus:outline-none focus:ring-2 focus:ring-brand-500/40"
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        placeholder="Say something..."
-        rows={1}
-      />
-      <Button type="submit" disabled={!text.trim()}>
-        Send
-      </Button>
-    </form>
+    <div className="flex justify-center w-full">
+      <form
+        onSubmit={handleSubmit}
+        className="pointer-events-auto w-full max-w-2xl flex items-end gap-2 p-3 rounded-xl bg-[rgba(255,255,255,0.05)] backdrop-blur-sm shadow-lg border border-white/10 focus-within:ring-2 focus-within:ring-brand-500/50"
+      >
+        <Textarea
+          ref={textareaRef}
+          className="peer flex-1 resize-none bg-transparent border-0 p-2 max-h-40 focus:outline-none placeholder:text-muted-foreground transition-all"
+          value={text}
+          onChange={handleChange}
+          placeholder="Send a message..."
+          rows={1}
+        />
+        <Button
+          type="submit"
+          size="icon"
+          disabled={!text.trim()}
+          className="rounded-full transition-transform hover:scale-110 active:shadow-[0_0_8px_rgba(255,255,255,0.4)]"
+        >
+          <SendHorizontal className="size-4" />
+          <span className="sr-only">Send</span>
+        </Button>
+      </form>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- give chat input a glassmorphic floating style inspired by Google Gemini
- animate textarea growth and auto-focus
- style send button with hover/active effects
- update tests for new placeholder

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686f8ec9e10883239eb172df1c81046f