### PR TITLE
Fix console warnings about defaultProps and refs

### DIFF
--- a/src/components/chat/MessageActions.tsx
+++ b/src/components/chat/MessageActions.tsx
@@ -15,7 +15,7 @@ export interface MessageActionsProps {
 /**
  * Actions available for each message.
  */
-export function MessageActions({ text, onDelete, className }: MessageActionsProps) {
+export function MessageActions({ text, onDelete = undefined, className }: MessageActionsProps) {
   const handleCopy = () => {
     navigator.clipboard.writeText(text)
     toast('Copied to clipboard')
@@ -47,7 +47,3 @@ export function MessageActions({ text, onDelete, className }: MessageActionsProp
   )
 }
 
-MessageActions.defaultProps = {
-  onDelete: undefined,
-  className: undefined,
-}

--- a/src/components/chat/SkeletonBubble.tsx
+++ b/src/components/chat/SkeletonBubble.tsx
@@ -9,7 +9,7 @@ export interface SkeletonBubbleProps {
 /**
  * Placeholder bubble shown while assistant is thinking.
  */
-export function SkeletonBubble({ className }: SkeletonBubbleProps) {
+export function SkeletonBubble({ className }: SkeletonBubbleProps = {}) {
   return (
     <div
       className={cn('rounded-lg bg-white/10 animate-pulse h-8 w-32', className)}
@@ -18,6 +18,3 @@ export function SkeletonBubble({ className }: SkeletonBubbleProps) {
   )
 }
 
-SkeletonBubble.defaultProps = {
-  className: undefined,
-}

--- a/src/components/commands/CommandPalette.tsx
+++ b/src/components/commands/CommandPalette.tsx
@@ -19,7 +19,7 @@ export interface CommandPaletteProps {
 /**
  * Global command palette triggered with meta+k / ctrl+k.
  */
-export function CommandPalette({ defaultOpen, className }: CommandPaletteProps) {
+export function CommandPalette({ defaultOpen = false, className }: CommandPaletteProps) {
   const [open, setOpen] = useState(!!defaultOpen)
 
   useHotkeys(
@@ -63,7 +63,3 @@ export function CommandPalette({ defaultOpen, className }: CommandPaletteProps) 
   )
 }
 
-CommandPalette.defaultProps = {
-  defaultOpen: false,
-  className: undefined,
-}

--- a/src/components/common/ThemeToggle.tsx
+++ b/src/components/common/ThemeToggle.tsx
@@ -11,7 +11,7 @@ export interface ThemeToggleProps {
 /**
  * Toggle between light and dark theme.
  */
-export function ThemeToggle({ className }: ThemeToggleProps) {
+export function ThemeToggle({ className }: ThemeToggleProps = {}) {
   const { theme, setTheme } = useTheme()
   const isDark = theme === 'dark'
   const toggle = () => setTheme(isDark ? 'light' : 'dark')
@@ -29,6 +29,3 @@ export function ThemeToggle({ className }: ThemeToggleProps) {
   )
 }
 
-ThemeToggle.defaultProps = {
-  className: undefined,
-}

--- a/src/components/common/Toaster.tsx
+++ b/src/components/common/Toaster.tsx
@@ -7,8 +7,7 @@ export interface ToasterProps extends ComponentProps<typeof SonnerToaster> {}
 /**
  * Application level toast provider using Sonner.
  */
-export function Toaster(props: ToasterProps) {
+export function Toaster(props: ToasterProps = {}) {
   return <SonnerToaster position="top-center" richColors {...props} />
 }
 
-Toaster.defaultProps = {}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -35,25 +35,24 @@ const buttonVariants = cva(
   }
 )
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
-  }) {
+const Button = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<"button"> &
+    VariantProps<typeof buttonVariants> & {
+      asChild?: boolean
+    }
+>(({ className, variant, size, asChild = false, ...props }, ref) => {
   const Comp = asChild ? Slot : "button"
 
   return (
     <Comp
+      ref={ref}
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
   )
-}
+})
+Button.displayName = "Button"
 
 export { Button, buttonVariants }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,9 +2,13 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentPropsWithoutRef<"textarea">
+>(({ className, ...props }, ref) => {
   return (
     <textarea
+      ref={ref}
       data-slot="textarea"
       className={cn(
         "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
@@ -13,6 +17,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
       {...props}
     />
   )
-}
+})
+Textarea.displayName = "Textarea"
 
 export { Textarea }


### PR DESCRIPTION
## Summary
- replace deprecated `defaultProps` with default params
- forward refs through `Button` and `Textarea` components

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686fa36e90c883239ec63414e0438d29