### PR TITLE
Fix tool permission storage

### DIFF
--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -144,12 +144,16 @@ export const useChatStore = create<ChatState>((set, get) => ({
     });
 
     try {
+      const permState = usePermissionStore.getState();
+      const allowedTools =
+        permState.allowedToolsByThread[threadId] || [];
+
       await invoke("generate_chat", {
         model: get().currentModel,
         prompt: text,
         ragEnabled: get().ragEnabled,
         enabledTools: get().enabledTools,
-        allowedTools: [],
+        allowedTools,
         threadId,
       });
       await done;


### PR DESCRIPTION
## Summary
- pass the allowed tools for the active thread to the backend when generating chat

## Testing
- `pnpm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686fa4d7b35c8323b06e92b31e3416ab