### PR TITLE
Reset tool permissions on every launch

### DIFF
--- a/src/stores/permissionStore.ts
+++ b/src/stores/permissionStore.ts
@@ -1,5 +1,9 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+
+// Clear any persisted permissions from previous versions
+if (typeof localStorage !== "undefined") {
+  localStorage.removeItem("permissions")
+}
 
 interface PermState {
   allowedToolsByThread: Record<string, string[]>;
@@ -12,8 +16,7 @@ interface PermState {
 }
 
 export const usePermissionStore = create<PermState>()(
-  persist(
-    (set) => ({
+  (set) => ({
       allowedToolsByThread: {},
       currentThreadId: "",
       pendingTool: null,
@@ -32,7 +35,5 @@ export const usePermissionStore = create<PermState>()(
         }),
       denyPermission: () => set({ pendingTool: null }),
       setThreadId: (id) => set({ currentThreadId: id }),
-    }),
-    { name: "permissions" }
-  )
+    })
 );


### PR DESCRIPTION
## Summary
- remove use of zustand `persist` middleware for permissions
- clear any stored permissions from previous versions

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686fa71597cc8323af5fbae658c596ec